### PR TITLE
general: Create flake8 action

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,17 @@
+name: flake8
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: grantmcconnaughey/lintly-flake8-github-action@v1.0
+        with:
+          # The GitHub API token to create reviews with
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # Fail if "new" violations detected or "any", default "new"
+          failIf: "any"
+          # Additional arguments to pass to flake8, default "." (current directory)
+          args: "."


### PR DESCRIPTION
Enable flake8 linting and annotation for PRs through GitHub actions.

Changes:
* .github/workflows/flake8.yml