### PR TITLE
frontend: Mentor profile page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7905,6 +7905,32 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
+    "jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha1-pltPoPEL2nGaBUQep7lMVfPhW64=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.1.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -11014,6 +11040,25 @@
         "webpack-dev-server": "3.11.0",
         "webpack-manifest-plugin": "2.2.0",
         "workbox-webpack-plugin": "4.3.1"
+      }
+    },
+    "react-share": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-4.3.1.tgz",
+      "integrity": "sha512-ikh0y8NKxhU7dQBXh1Jccd1ANLb9WNYaSonln33yLyNYo2HTBRp9D6HkTsFlgX/2J9GPsGLqhzzpDNiVKx3WVA==",
+      "dev": true,
+      "requires": {
+        "classnames": "^2.2.5",
+        "jsonp": "^0.2.1"
+      }
+    },
+    "react-social-icons": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/react-social-icons/-/react-social-icons-4.1.0.tgz",
+      "integrity": "sha512-wbwSbyS4QWjpL6U+GFZDBrE5Ao8px0QkRgo0XkxDHF2LNRsFNErSDnIPKiowhQ7t7IyrSA2HYrEw7ETgpVTg+Q==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.6.2"
       }
     },
     "react-transition-group": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,5 +35,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "react-share": "^4.3.1",
+    "react-social-icons": "^4.1.0"
   }
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import SignupPage from './pages/SignupPage';
 import ProfilePage from './pages/ProfilePage';
 import { CookiesProvider } from "react-cookie";
 import MakeList from './pages/MakeList';
+import MentorPage from './pages/MentorPage'
 
 function App() {
   return (
@@ -27,6 +28,7 @@ function App() {
             <Route path='/login' component={LoginPage} exact />
             <Route path='/signup' component={SignupPage} exact />
             <Route path='/profile' component={ProfilePage} exact />
+            <Route path='/mentor/:id' component={MentorPage} exact />
             <Route path='/profile/makelist' component={MakeList} exact />
           </Container>
         </main>

--- a/frontend/src/components/MentorCard.jsx
+++ b/frontend/src/components/MentorCard.jsx
@@ -1,17 +1,20 @@
 import React from 'react'
 import { Card } from 'react-bootstrap'
+import { Link } from 'react-router-dom'
 
 const MentorCard = ({profiles}) => {
   console.log(profiles)
     return (
         <Card border='primary' className='my-3 p-3 rounded' style={{height: '80%'}}>
             <Card.Body>
+                <Link to={`/mentor/${profiles.fields.username}`}>
                     <Card.Title as='h6'>{profiles.fields.name}</Card.Title>
                     <Card.Subtitle className="mb-2 text-muted">Frontend, Backend</Card.Subtitle>
                     <Card.Text>
                         Works at - {profiles.fields.company}
                     </Card.Text>
                     <Card.Link href="#">Contact Mentor</Card.Link>
+                </Link>
             </Card.Body>
         </Card>
     )

--- a/frontend/src/components/MentorList.jsx
+++ b/frontend/src/components/MentorList.jsx
@@ -1,0 +1,54 @@
+import React, { Component } from 'react'
+import { Col, Row } from 'react-bootstrap'
+import ProfileListCard from './ProfileListCard'
+import axios from 'axios'
+
+class MentorList extends Component {
+    constructor() {
+        super();
+        this.state = {
+            profile: {},
+            username: '',
+            curations: [],
+            fields: {}
+        };
+    }
+
+    componentDidMount(username, profile, curations, fields) {
+        const user = window.location.pathname.split('/mentor/')[1]
+        const send = {
+            username: user
+        }
+
+        axios.post('https://mentored-n3wkrveexq-uc.a.run.app/api/get_profile', send)
+            .then((res) => {
+                profile = res.data[0]
+                fields = profile.fields
+                curations = profile.curations
+                this.setState({
+                    profile: profile,
+                    curations: curations,
+                    fields: fields
+                })
+            })
+            .catch(err => {
+                console.error(err)
+            })
+    }
+    render() {
+        const { curations, fields } = this.state;
+
+        return (
+            <>
+                <Row>
+                    {curations.map(curation => (
+                        <Col sm={12} md={6} lg={6} key={curation.pk}>
+                            <ProfileListCard curations={curation} fields={fields} />
+                        </Col>
+                    ))}
+                </Row>
+            </>
+        )
+    }
+}
+export default MentorList

--- a/frontend/src/pages/MentorPage.jsx
+++ b/frontend/src/pages/MentorPage.jsx
@@ -1,0 +1,95 @@
+import React, { Component } from 'react'
+import { Link } from 'react-router-dom';
+import { Form, Button, Row, Col, Container } from 'react-bootstrap';
+import axios from 'axios'
+import MentorList from '../components/MentorList';
+import {
+    EmailIcon, 
+    TelegramIcon
+} from "react-share";
+import { SocialIcon } from 'react-social-icons';
+
+class MentorPage extends Component {
+    constructor() {
+        super();
+        this.state = {
+            profile: {},
+            username: '',
+            fields: {},
+            list: {}
+        };
+    }
+
+    componentDidMount(username, profile, fields, list) {
+        const user = window.location.pathname.split('/mentor/')[1]
+        const send = {
+            username: user
+        }
+
+        axios.post('https://mentored-n3wkrveexq-uc.a.run.app/api/get_profile', send)
+            .then((res) => {
+                profile = res.data[0]
+                fields = profile.fields
+                list = profile.curations
+                this.setState({
+                    profile: profile,
+                    fields: fields,
+                    list: list,
+                    username: user
+                })
+            })
+            .catch(err => {
+                console.error(err)
+            })
+    }
+    render() {
+        const { username, fields } = this.state;
+        return (
+            <>
+            {<Row>
+                <Col md={3}>
+                    <h2>Mentor Profile</h2>
+                    <Form>
+                        <Form.Group controlId='name'>
+                            <Form.Label>Name</Form.Label>
+                            <Form.Control disabled type='name' placeholder={fields.name}></Form.Control>
+                        </Form.Group>
+                        <Form.Group controlId='username'>
+                            <Form.Label>Username</Form.Label>
+                            <Form.Control disabled name='username' type='text' placeholder={fields.username}>
+                            </Form.Control>
+                        </Form.Group>
+
+                        <Form.Group controlId='company'>
+                            <Form.Label>Company</Form.Label>
+                            <Form.Control disabled type='text' name='company' placeholder={fields.company}></Form.Control>
+                        </Form.Group>
+
+                    </Form>
+                    <h4>Contact</h4>
+                    <Container>
+                        <Row>
+                            <Col><SocialIcon url="https://twitter.com/" /></Col>
+                            <Col><SocialIcon url="https://linkedin.com/in" /></Col>
+                            <Col><SocialIcon url="https://medium.com/" /></Col>
+                        </Row>
+                        <Row>
+                            <Col>.</Col>
+                        </Row>
+                        <Row>
+                            <Col><SocialIcon url="https://github.com/" fgColor="#ffffff" bgColor="#000000"/></Col>
+                            <Col><EmailIcon size={50} round={true} iconFillColor='red'/></Col>
+                            <Col><TelegramIcon size={50} round={true} /></Col>
+                        </Row>
+                    </Container>
+                </Col>
+                <Col className='profilecur' md={9}>
+                    <h2>Mentor's Curated Lists</h2>
+                    <MentorList />
+                </Col>
+            </Row>}
+            </>
+        )
+    }
+}
+export default MentorPage


### PR DESCRIPTION
Closes #47 

Changes:
Add a profile page so that when a normal user clicks on a mentor profile, a new page with all mentor's information and lists is opened. 